### PR TITLE
Remove embedded badge (theme.plist)

### DIFF
--- a/theme.plist
+++ b/theme.plist
@@ -22,7 +22,7 @@
 			<key>Inline</key>
 			<false/>
 			<key>Show</key>
-			<true/>
+			<false/>
 			<key>Swap</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
Cloning that repo as is will display an ugly embedded-themed badge. 
Disabling Badges to get desired output.